### PR TITLE
Add phase-specific colored backgrounds to timer display

### DIFF
--- a/src/components/Timer/Timer.test.tsx
+++ b/src/components/Timer/Timer.test.tsx
@@ -38,4 +38,34 @@ describe('Timer', () => {
     expect(screen.getByText('Work')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
   });
+
+  it('should display blue background during prepare phase', () => {
+    render(<Timer />);
+
+    const container = screen.getByTestId('timer-container');
+    expect(container).toHaveClass('bg-prepare');
+  });
+
+  it('should display red background during work phase', () => {
+    render(<Timer />);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    const container = screen.getByTestId('timer-container');
+    expect(container).toHaveClass('bg-work');
+  });
+
+  it('should display green background during rest phase', () => {
+    render(<Timer />);
+
+    // Advance through prepare (5s) and work (5s) to get to rest
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    const container = screen.getByTestId('timer-container');
+    expect(container).toHaveClass('bg-rest');
+  });
 });

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -11,7 +11,7 @@ export const Timer = () => {
   const phaseColors = {
     prepare: 'bg-prepare',
     work: 'bg-work',
-    rest: 'bg-prepare',
+    rest: 'bg-rest',
   };
 
   const phaseLabels = {
@@ -21,7 +21,10 @@ export const Timer = () => {
   };
 
   return (
-    <div className={`min-h-screen flex flex-col items-center justify-center ${phaseColors[phase]}`}>
+    <div
+      data-testid="timer-container"
+      className={`min-h-screen flex flex-col items-center justify-center ${phaseColors[phase]}`}
+    >
       <div className="text-white text-center">
         <h1 className="text-5xl font-light mb-8">
           {phaseLabels[phase]}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,9 @@ export default {
   theme: {
     extend: {
       colors: {
-        'prepare': '#22c55e',
+        'prepare': '#3b82f6',
         'work': '#ef4444',
+        'rest': '#22c55e',
       },
     },
   },


### PR DESCRIPTION
Implements blue background for prepare phase, red for work, and green for rest to provide clear visual feedback during workouts. Includes test coverage for all phase background colors.